### PR TITLE
[6-1] 07. Spring Multi Module 의존성 설정(3) - Bean을 사용한 모듈간 의존성 테스트

### DIFF
--- a/module-api/src/main/java/dev/be/ModuleApiApplication.java
+++ b/module-api/src/main/java/dev/be/ModuleApiApplication.java
@@ -1,4 +1,4 @@
-package dev.be.moduleapi;
+package dev.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/module-api/src/main/java/dev/be/moduleapi/service/DemoService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/service/DemoService.java
@@ -2,15 +2,21 @@ package dev.be.moduleapi.service;
 
 
 import dev.be.modulecommon.enums.CodeEnum;
+import dev.be.modulecommon.service.CommonDemoService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DemoService {
+
+    private final CommonDemoService commonDemoService;
 
     public String save() {
         log.info(CodeEnum.SUCCESS.getCode());
+        log.info(commonDemoService.commonService());
         return "save";
     }
 

--- a/module-common/src/main/java/dev/be/modulecommon/service/CommonDemoService.java
+++ b/module-common/src/main/java/dev/be/modulecommon/service/CommonDemoService.java
@@ -1,0 +1,10 @@
+package dev.be.modulecommon.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommonDemoService {
+    public String commonService() {
+        return "commonService";
+    }
+}


### PR DESCRIPTION
`module-common` 에서 정의한 service bean 을 `module-api` 사용하고자 구현하면, 에러가 발생할 수 있다.

그 이유는 application 이 실행할 때, 해당 application 의 하위 경로에 존재하는 `bean` 을 scan 하여  생성하기 때문에, 이런 과정을 component scan 이라고 한다.

만약 의존성 module 에서 `bean` 의 경로가 동일 하다면,  기본 설정인 component scan 에서도 성공적으로 확인 및 사용 가능해진다.

그런데 현재 구현에서 `applciation` class 의 위치는 dev/be/moduleapi 이고 module 내 사용하고자 하는 service 의 경로는 dev/be/modulecommon/service/CommonDemoService.java 이므로 중간 'dev/be/' 까지만 같음을 알 수 있다.

이 문제를 해결하기 위해 application class 의 위치를  dev/be/ 에 존재하도록 이동시키면, 상위 경로가 동일한 상태가 되어 의존성 module `bean` 의 사용이 가능해진다.

This closes #4 