### PR TITLE
[6-1] 07. Spring Multi Module 의존성 설정(4) - 실무에서 사용하는 모듈간 Component 스캔 방법

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
+++ b/module-api/src/main/java/dev/be/moduleapi/ModuleApiApplication.java
@@ -1,9 +1,11 @@
-package dev.be;
+package dev.be.moduleapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(
+        scanBasePackages = {"dev.be.moduleapi", "dev.be.modulecommon"}
+)
 public class ModuleApiApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
이전 issue 에서와 같이 application 의 경로를 맞추기 위해 작업하는 것은 매우 번거롭고, 수많은 module 간 경로를 맞추는 것은불가능하면, 필요없는 하위 경로까지 scan 이 적용되어야 할 수 있다.

이를 해결하기 위해, @SpringBootApplcation 의 option 인 scanBasePackages  에 각 module 의 `bean` 생성이 필요한 위치를 포함시켜주면 해당 경로를 compenent scan 함으로써,  경로 명을 맞출 필요도 없고, 정확히 필요한 경로만 포함시킴으로써 scan 과정이 효율적으로 이루어질 수 있도록 구성시켜 줄 수 있다.

This closes #5