### PR TITLE
[6-1] 07. Spring Multi Module 의존성 설정(8) - Gradle을 사용해 빌드 및 배포

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -37,3 +37,9 @@ tasks.named('test') {
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}
+
+// ./gradlew clean :module-api:buildNeeded --stacktrace --info --refresh-dependencies -x test
+//   기존 build 폴더내용 삭제하고, build module stacktrace 보여주고, logging leve info, 의존성 refresh, test code (pass/fail) skip 하여 build 해라
+
+// java -jar module-api-0.0.1-SNAPSHOT.jar
+// debug -> info -> warn -> error

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -37,3 +37,17 @@ tasks.named('test') {
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}
+
+// bootJar 를 true 설정 시 .jar 파일 생성 해당 파일은 dependicies, class, resources 를 포함함
+// 그러나  common module 은 `XXX.jar` 파일이 필요 없음.
+// (만약 true 이면 main class 를 찾는다. 그런데 해당 module 에선 삭제되었기 때문에 에러가 발행함.)
+tasks.bootJar { enabled = false }
+
+// bootJar :       `XXX.jar`  파일 생성
+// jar     : `XXX-plain.jar`  파일 생성 -> dependency 를 가지고 있지 않음. -> 서버 실행 X
+tasks.jar { enabled = true }
+
+// ./gradlew clean :module-api:buildNeeded --stacktrace --info --refresh-dependencies -x test
+//   기존 build 폴더내용 삭제하고, build module stacktrace 보여주고, logging leve info, 의존성 refresh, test code (pass/fail) skip 하여 build 해라
+
+// debug -> info -> warn -> error


### PR DESCRIPTION
server 환경에서 multi module project build 를 위한 command 및 설정 관련 내용 학습.

moulde-common/build.gradle
 - 프로젝트를 build 하면 기본적으로 xxx.jar / xxx-plain.jar 파일이 생성된다. xxx.jar file 은 depedencies, classes, resources 내용을 포함하고 있으며, xxx-plain.jar 은 dependencies 는 포함되지 않는다. xxx.jar 은 즉 실행 main.class 에 대한 build 파일이다. 그런데 module-common 의 경우 의존성 module 이므로 applciation class 는 존재하지 않으므로, xxx.jar 를 생성하고자 하면 에러가 발생한다. 따라서 bootJar 은 false 로 xxx.jar 생성 진행을 하지 않고, tasks.jar 만 활성화 하여 xxx-plain.jar 만 생성되도록 구현한다.

1. cli build 해당 project root folder 위치에서 다음의 cli 를 실행
`./gradlew clean :module-api:buildNeeded --stacktrace --info --refresh-dependencies -x test`
- `./gradlew` : gradle 명령어
- `clean` : 기존 build 폴더 및 파일 제거
- `:module-api:buildNeeded` : 실행 module
- `--stacktace` : stack trace  출력
- `--info` : logging level
- `--refresh-dependencies` : 의존성 libraries refresh
- `-x test` :  test (pass/fail) 확인 skip 하여 build

2. api module/build/libs 이동
3. `java -jar XXX.jar` 로 실행

This closes #9 